### PR TITLE
FIX: vaccuum connection + overflowing variable.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,8 @@ export enum WorkMode {
 	NO_SWEEP = 'Nosweep',
 	SMALL_ROOM = 'SmallRoom',
 	EDGE = 'Edge',
-	SPOT = 'Spot'
+	SPOT = 'Spot',
+    CHARGING = "Charging"
 }
 
 export interface StatusResponse {
@@ -84,10 +85,10 @@ export class RoboVac {
 
 	statuses: StatusResponse = null;
 	lastStatusUpdate: number = null;
-	maxStatusUpdateAge: number = 30 * 1000; //10 Seconds
+	maxStatusUpdateAge: number = 1000 * (1 * 60); //60 Seconds
 	timeoutDuration: number;
 
-	constructor(config: { deviceId: string, localKey: string }, debugLog: boolean = false, timeoutDuration = 2) {
+	constructor(config: { deviceId: string, localKey: string, ip: string, port: number }, debugLog: boolean = false, timeoutDuration = 2) {
 		this.debugLog = debugLog;
 		if(!config.deviceId) {
 			throw new Error('You must pass through deviceId');
@@ -95,7 +96,11 @@ export class RoboVac {
 		this.api = new TuyAPI(
 			{
 				id: config.deviceId,
-				key: config.localKey
+				key: config.localKey,
+                ip: config.ip,
+                port: config.port,
+                version: '3.3',
+                issueRefreshOnConnect: true
 			}
 		);
 		this.timeoutDuration = timeoutDuration;
@@ -120,10 +125,16 @@ export class RoboVac {
 			}
 		});
 
+        this.api.on('dp-refresh', data => {
+            if (debugLog) {
+                console.log('DP_REFRESH data from device: ', data);
+				console.log('Status Updated!');
+			}
+        });
+
 		this.api.on('data', (data: StatusResponse) => {
-			this.statuses = data;
-			this.lastStatusUpdate = (new Date()).getTime();
 			if (debugLog) {
+                console.log('Data from device:', data);
 				console.log('Status Updated!');
 			}
 		});
@@ -237,6 +248,17 @@ export class RoboVac {
 		}
 	}
 
+    async startCharging(force: boolean = false) {
+		if (this.debugLog) {
+			console.log('Starting Charging', JSON.stringify(await this.getStatuses(force), null, 4));
+		}
+		await this.setWorkMode(WorkMode.CHARGING);
+
+		if (this.debugLog) {
+			console.log('Cleaning Started!');
+		}
+	}
+
 	async getWorkStatus(force: boolean = false): Promise<WorkStatus> {
 		let statuses = await this.getStatuses(force);
 		return <WorkStatus>statuses.dps[this.WORK_STATUS];
@@ -259,7 +281,7 @@ export class RoboVac {
 	}
 
 	async setFindRobot(state: boolean) {
-		await this.doWork(async () => {
+		return await this.doWork(async () => {
 			await this.set({
 				[this.FIND_ROBOT]: state
 			})
@@ -285,9 +307,10 @@ export class RoboVac {
 		if (this.debugLog) {
 			console.log(`Setting: ${JSON.stringify(data, null, 4)}`);
 		}
-		await this.api.set({
+		return await this.api.set({
 			multiple: true,
-			data: data
+			data: data,
+            shouldWaitForResponse: true
 		});
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ export enum WorkMode {
 	SMALL_ROOM = 'SmallRoom',
 	EDGE = 'Edge',
 	SPOT = 'Spot',
-    CHARGING = "Charging"
+    CHARGING = 'Charging'
 }
 
 export interface StatusResponse {
@@ -85,7 +85,7 @@ export class RoboVac {
 
 	statuses: StatusResponse = null;
 	lastStatusUpdate: number = null;
-	maxStatusUpdateAge: number = 1000 * (1 * 60); //60 Seconds
+	maxStatusUpdateAge: number = 1000 * (1 * 30); //30 Seconds
 	timeoutDuration: number;
 
 	constructor(config: { deviceId: string, localKey: string, ip: string, port: number }, debugLog: boolean = false, timeoutDuration = 2) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ export class RoboVac {
 	maxStatusUpdateAge: number = 1000 * (1 * 30); //30 Seconds
 	timeoutDuration: number;
 
-	constructor(config: { deviceId: string, localKey: string, ip: string, port: number }, debugLog: boolean = false, timeoutDuration = 2) {
+	constructor(config: { deviceId: string, localKey: string, ip: string, port: 6668 }, debugLog: boolean = false, timeoutDuration = 2) {
 		this.debugLog = debugLog;
 		if(!config.deviceId) {
 			throw new Error('You must pass through deviceId');


### PR DESCRIPTION
Added a PR to the eufy-robovac repo.
Found that you have to force the IP. This wil fix the `Error: find() timed out. Is the device powered on and the ID or IP correct?`
Also giving a `issueRefreshOnConnect` will work with the statuses on startup of the Lib.

Next to that. I think that the memory issue comes from the `on('data')` event. the statuses are written to the variable. But when the vaccuum is moving it's overflowing and overwriting the complete list of the DPS values and only sending the location: `Data from device: { dps: { '108': '[-307,2396,-8]' }, t: 1619003237 }` instead of 

```Data from device: {
  dps: {
    '102': 'Quiet',
    '104': 76,
    '105': 'MopHigh',
    '107': false,
    '108': '[-307,2396,-8]',
    '109': 10,
    '110': 0,
    '111': 43,
.....
  ```

Hope this helps. :) 