### PR TITLE
Moving the default port value to the port parameter in the Tuya API constructor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ export class RoboVac {
     maxStatusUpdateAge: number = 1000 * (1 * 30); //30 Seconds
     timeoutDuration: number;
 
-    constructor(config: RoboVacConfig, debugLog: boolean = false, timeoutDuration = 5) {
+    constructor(config: RoboVacConfig, debugLog: boolean = false, timeoutDuration = 2) {
         this.debugLog = debugLog;
         if (!config.deviceId) {
             throw new Error('You must pass through deviceId');

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ export class RoboVac {
     maxStatusUpdateAge: number = 1000 * (1 * 30); //30 Seconds
     timeoutDuration: number;
 
-    constructor(config: RoboVacConfig, debugLog: boolean = false, timeoutDuration = 2) {
+    constructor(config: RoboVacConfig, debugLog: boolean = false, timeoutDuration = 5) {
         this.debugLog = debugLog;
         if (!config.deviceId) {
             throw new Error('You must pass through deviceId');
@@ -97,8 +97,8 @@ export class RoboVac {
             {
                 id: config.deviceId,
                 key: config.localKey,
-                ip: config.ip || 6668,
-                port: config.port,
+                ip: config.ip,
+                port: config.port || 6668,
                 version: '3.3',
                 issueRefreshOnConnect: true
             }


### PR DESCRIPTION
I was having trouble connecting my Robovac 30C via this API. Specifically, I was getting this error message after running the demo:

`Connecting...
Robovac Error {}
Disconnected!`

I found moving 6668 to the port parameter fixed this, or at least allowed me to receive the nebulous "find() timed out" error. I'm not sure of the original reasoning for including 6668 in the ip field, so let me know if I'm misinterpreting something. 

It would also be helpful to have a comment or a constant describing what 6668 is. 